### PR TITLE
Add external feed plan

### DIFF
--- a/documentation/external-aircraft-feed-example.md
+++ b/documentation/external-aircraft-feed-example.md
@@ -1,0 +1,49 @@
+# External Aircraft Feed Example
+
+The JSON snippet below illustrates the minimum set of data fields required to create aircraft from an external source. Each object represents one aircraft to be spawned or handed off to OpenScope.
+
+```json
+[
+  {
+    "callsign": "DLH401",
+    "airline": "dlh",
+    "type": "A320",
+    "category": "departure",
+    "origin": "EDDH",
+    "destination": "EDDF",
+    "route": "EDDH.AMLUH8G.AMLUH",
+    "altitude": 16000,
+    "speed": 250,
+    "heading": 330,
+    "spawnTime": "2025-06-03T18:00:00Z"
+  },
+  {
+    "callsign": "DLH902",
+    "airline": "dlh",
+    "type": "A319",
+    "category": "arrival",
+    "origin": "EDDF",
+    "destination": "EDDH",
+    "route": "BOGMU.BOGMU05.EDDH",
+    "altitude": 30000,
+    "speed": 320,
+    "waypoints": ["BOGMU", "DH255"],
+    "spawnTime": "2025-06-03T18:05:00Z"
+  }
+]
+```
+
+### Field descriptions
+
+- `callsign` – IFR callsign or flight number.
+- `airline` – ICAO identifier used to pick the fleet.
+- `type` – aircraft model (ICAO code). Optional if the airline fleet provides one.
+- `category` – `arrival`, `departure`, or `overflight`.
+- `origin` / `destination` – airports relevant to the category.
+- `route` – route string or list of fixes.
+- `altitude` – spawn altitude or requested altitude in feet MSL.
+- `speed` – spawn speed in knots.
+- `heading` or `waypoints` – initial heading or array of fixes to fly immediately.
+- `spawnTime` – when the aircraft should be created. External logic controls the timing.
+
+This example uses standard JSON so that feeds can be produced by any tooling capable of generating JSON. Each object can be validated against a matching JSON Schema to ensure the required properties are present before injecting traffic into the simulator.

--- a/documentation/external-aircraft-feed-plan.md
+++ b/documentation/external-aircraft-feed-plan.md
@@ -1,0 +1,36 @@
+# External Aircraft Feed Requirements and Plan
+
+This document outlines the required data for creating aircraft in OpenScope from an external source and proposes tasks to decouple external traffic from the internal Traffic Generator.
+
+## Minimum Required Aircraft Data
+
+Based on the spawn pattern documentation and the code that builds aircraft objects, each externally supplied aircraft must provide:
+
+- **Airline and weight** – used to choose an aircraft type and callsign.
+- **Category** – `arrival`, `departure`, or `overflight`.
+- **Route** or list of waypoints – defines the path to follow.
+- **Altitude** – spawn altitude or requested altitude.
+- **Speed** – indicated airspeed at spawn.
+- **Heading** or **initial fixes** – direction or fixes to fly immediately.
+- **Spawn rate information** – if the external feed manages spawn timing.
+
+These fields mirror the required spawn pattern keys described in `spawnPatternReadme.md` and `spawnPatternMethodReadme.md`.
+
+Internally, aircraft are constructed with properties such as airline, callsign, type, altitude, position, route, and commands as seen in `_buildAircraftProps` within `AircraftController.js`.
+
+## Proposed Tasks for Decoupling
+
+1. **Expose a Public Creation Interface**
+   - Create a method (or event) on `AircraftController` that accepts an initialization object similar to `_buildAircraftProps` and instantiates an `AircraftModel` without relying on `SpawnPatternModel`.
+2. **Design External Feed Parser**
+   - Build a module to parse external data into the initialization format. This parser should validate required fields and convert coordinates into the simulation's position model.
+3. **Separate Spawn Scheduling**
+   - Allow the external feed to determine when aircraft are added. The Traffic Generator would continue to handle internal spawn patterns independently.
+4. **Synchronization and Updates**
+   - If real‑time updates are required, provide a mechanism to update aircraft state (position, altitude, speed) from the external feed while respecting game physics.
+5. **Configuration and Controls**
+   - Add user controls to enable/disable external traffic and to select the data source. Ensure that existing traffic settings remain functional.
+6. **Documentation and Examples**
+   - Document the expected external feed format and provide example scripts demonstrating how to push aircraft data into OpenScope via the new interface.
+
+This sequence isolates the new external feeding mechanism from the existing Traffic Generator while preserving the ability to spawn aircraft internally.


### PR DESCRIPTION
## Summary
- document requirements for external aircraft feed and a plan for decoupling traffic
- provide example feed data for operations at Hamburg Airport

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm test` *(fails: nyc not found)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_683edd602314833381b0ac0494634c3a